### PR TITLE
Talk template creates correct project links

### DIFF
--- a/content/templates/talk.html
+++ b/content/templates/talk.html
@@ -64,7 +64,7 @@
       $if(project-name)$
         <span class="float-right align-middle">
         $if(project)$
-          <a href="/project/$project$">$project-name$</a>
+          <a href="/projects/$project$">$project-name$</a>
         $else$
           $project-name$
         $endif$


### PR DESCRIPTION
Updated the link with plural route. Will result in 404 otherwise.

# Issue

1. https://qfpl.io/talks/
1. Click "Reflex" in "Reflex: front-end development done awesome".
1. https://qfpl.io/project/reflex
1. 404