### PR TITLE
Consolidate variables that reference boot partition

### DIFF
--- a/content/posts/installing-nixos.md
+++ b/content/posts/installing-nixos.md
@@ -185,11 +185,11 @@ machine.
 
 ### Create our filesystems
 
-In the below snippet, `$BOOT` refers to the boot partition created above - something like `/dev/sda1`.
+In the below snippet, `$BOOT_PARTITION` refers to the boot partition created above - something like `/dev/sda1`.
 
 ```
 -- Create a FAT32 filesystem on our boot partition
-# mkfs.vfat -n boot $BOOT
+# mkfs.vfat -n boot $BOOT_PARTITION
 
 -- Create an ext4 filesystem for our root partition
 # mkfs.ext4 -L nixos /dev/nixos-vg/root


### PR DESCRIPTION
Hi QFPL Team 👋 

Thanks for putting together [Installing NixOS](https://qfpl.io/posts/installing-nixos/)! I wasn't familiar with the partitioning process which is very explained in the blog post.

I spotted an opportunity to contribute and submitted for your consideration.

The installing NixOS tutorial uses two variables to reference the boot partition `$BOOT` and
`$BOOT_PARTITION`. This commit consolidates the references to use `$BOOT_PARTITION` which is consistent with rest of the blog post.